### PR TITLE
Translate `Nationality` template field with template lang

### DIFF
--- a/src/components/templates/TemplateBasic.vue
+++ b/src/components/templates/TemplateBasic.vue
@@ -1,7 +1,11 @@
-<script setup>
+<script setup lang="ts">
 defineProps(['movie'])
-const regionNamesFr = new Intl.DisplayNames(['fr'], { type: 'region' });
+const templateLang = 'fr';
+const regionNames = new Intl.DisplayNames([templateLang], { type: 'region', style: 'long' });
 
+function translateRegion(region: string): string {
+    return regionNames.of(region);
+}
 </script>
 
 <template>
@@ -14,7 +18,7 @@ const regionNamesFr = new Intl.DisplayNames(['fr'], { type: 'region' });
     <p>[b]Acteurs :[/b] {{ movie.getActors() }}</p>
     <p>[b]Réalisateurs :[/b] {{ movie.getDirectors() }} </p>
     <p>[b]Genre(s) :[/b] {{ movie.getGenres() }}</p>
-    <p>[b]Nationalité :[/b] {{ movie.getFirstOriginCountry() }}</p>
+    <p>[b]Nationalité :[/b] {{ translateRegion(movie.getFirstOriginCountry()) }}</p>
     <p>[b]Durée :[/b] {{ movie.duration }}</p>
     <p>[b]Date de sortie :[/b] {{ movie.getFormattedReleaseDate() }}</p>
     <br>

--- a/src/models/Movie.ts
+++ b/src/models/Movie.ts
@@ -80,10 +80,10 @@ export default class Movie {
   }
 
   /**
-   * @returns {string}
+   * @returns {string} The first origin country not translated
    */
   getFirstOriginCountry(): string {
-    return new Intl.DisplayNames([navigator.language], { type: 'region' }).of(this.originCountries[0]);
+    return this.originCountries[0];
   }
 
   /**


### PR DESCRIPTION
I've remove the implicit translation in `Movie.ts` that was using the web-browser lang instead of the template lang.
I've choosen the approach to do the translation in the template, since it's the template responsability to format the data acordingly.

Closes #8